### PR TITLE
Fix: flip canvas window

### DIFF
--- a/LinkedIdeasTests/CanvasViewControllerMouseTests.swift
+++ b/LinkedIdeasTests/CanvasViewControllerMouseTests.swift
@@ -14,6 +14,7 @@ import XCTest
 extension CanvasViewControllerTests {
   func testDoubleClickInCanvas() {
     let clickedPoint = NSPoint(x: 200, y: 300)
+
     let mouseEvent = createMouseEvent(clickCount: 2, location: clickedPoint)
 
     canvasViewController.mouseDown(with: mouseEvent)

--- a/LinkedIdeasTests/CanvasViewControllerTests.swift
+++ b/LinkedIdeasTests/CanvasViewControllerTests.swift
@@ -18,6 +18,11 @@ extension CanvasViewController {
 }
 
 class CanvasViewControllerTests: XCTestCase {
+  // this is used because of flipping the CanvasView for working with iOS
+  func invertY(_ point: NSPoint) -> NSPoint {
+    return NSPoint(x: point.x, y: -point.y)
+  }
+
   func createMouseEvent(clickCount: Int, location: NSPoint, shift: Bool = false) -> NSEvent {
     var flags: NSEvent.ModifierFlags = NSEvent.ModifierFlags.function
 
@@ -27,7 +32,7 @@ class CanvasViewControllerTests: XCTestCase {
 
     return NSEvent.mouseEvent(
       with: .leftMouseDown,
-      location: location,
+      location: invertY(location),
       modifierFlags: flags,
       timestamp: 2,
       windowNumber: 0,


### PR DESCRIPTION
the tests needed to be fixed considering that the clicks are made in an
inverted coordinated system.

For the rest of the test the coordinates work as before, but internally,
before sending the event to the view, the coordinate of those clicks
will be inverted, simulating what the iOS coordinate system will see.

Related to #67
Fixes #71

Created #72 for this not to happen again.